### PR TITLE
Add path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
         version: "2021.1.1"
         install-go: false
         cache-key: ${{ matrix.go }}
-        path: ${{ matrix.dir }}
+        working-directory: ${{ matrix.dir }}
 ```
 
 
@@ -99,7 +99,7 @@ The action itself requires at least Go 1.16.
 String to include in the cache key, in addition to the default, which is `runner.os`.
 This is useful when using multiple Go versions.
 
-### `path`
+### `working-directory`
 
 Relative path to the working directory Staticcheck should be executed in.
 This is useful when dealing with multiple projects within one repository.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ jobs:
     name: "Run CI"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - uses: dominikh/staticcheck-action@v1.0.0
+    - uses: dominikh/staticcheck-action@v1.1.0
       with:
         version: "2021.1.1"
 ```
@@ -36,11 +36,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        go: ["1.16.x", "1.17.x"]
+        os:  ["windows-latest", "ubuntu-latest", "macOS-latest"]
+        go:  ["1.16.x", "1.17.x"]
+        dir: ["server", "client"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 1
     - uses: WillAbides/setup-go-faster@v1.7.0
@@ -48,11 +49,12 @@ jobs:
         go-version: ${{ matrix.go }}
     - run: "go test ./..."
     - run: "go vet ./..."
-    - uses: dominikh/staticcheck-action@v1.0.0
+    - uses: dominikh/staticcheck-action@v1.1.0
       with:
         version: "2021.1.1"
         install-go: false
         cache-key: ${{ matrix.go }}
+        path: ${{ matrix.dir }}
 ```
 
 
@@ -96,3 +98,12 @@ The action itself requires at least Go 1.16.
 
 String to include in the cache key, in addition to the default, which is `runner.os`.
 This is useful when using multiple Go versions.
+
+### `path`
+
+Relative path to the working directory Staticcheck should be executed in.
+This is useful when dealing with multiple projects within one repository.
+
+Can be easily combined with a directory [`matrix`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix),
+see the advanced example above.
+

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ inputs:
       String to include in the cache key, in addition to the default, which is runner.os.
       This is useful when using multiple Go versions.
     required: false
-  path:
+  working-directory:
     description: |
       Relative path to the working directory Staticcheck should be executed in.
       This is useful when dealing with multiple projects within one repository.
@@ -76,7 +76,7 @@ runs:
         buildTags: ${{ inputs.build-tags }}
         minGoVersion: ${{ inputs.min-go-version }}
         checks: ${{ inputs.checks }}
-      working-directory: ${{ inputs.path }}
+      working-directory: ${{ inputs.working-directory }}
       run: |
         export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
         go install "honnef.co/go/tools/cmd/staticcheck@${version}"

--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,7 @@ inputs:
     required: false
   path:
     description: |
-      The relative path to the working directory in $GITHUB_WORKSPACE staticcheck should be executed in.
+      Relative path to the working directory in $GITHUB_WORKSPACE staticcheck should be executed in.
     required: false
     default: "."
 

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
 
       If unset, this will default to the Go version specified in your
       go.mod.
-      
+
       See https://staticcheck.io/docs/running-staticcheck/cli/#go
       for more information.
     required: false
@@ -47,6 +47,12 @@ inputs:
       String to include in the cache key, in addition to the default, which is runner.os.
       This is useful when using multiple Go versions.
     required: false
+  path:
+    description: |
+      The relative path to the working directory in $GITHUB_WORKSPACE staticcheck should be executed in.
+    required: false
+    default: "."
+
 runs:
   using: "composite"
   steps:
@@ -69,6 +75,7 @@ runs:
         buildTags: ${{ inputs.build-tags }}
         minGoVersion: ${{ inputs.min-go-version }}
         checks: ${{ inputs.checks }}
+      working-directory: ${{ inputs.path }}
       run: |
         export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
         go install "honnef.co/go/tools/cmd/staticcheck@${version}"

--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,8 @@ inputs:
     required: false
   path:
     description: |
-      Relative path to the working directory in $GITHUB_WORKSPACE staticcheck should be executed in.
+      Relative path to the working directory Staticcheck should be executed in.
+      This is useful when dealing with multiple projects within one repository.
     required: false
     default: "."
 


### PR DESCRIPTION
In this PR I would like to add:
 - A path option that can be used to set the working directory for staticcheck. This can be useful for some repositories that contain multiple, encapsulated projects with their own dependencies. Since this action is included via `uses` a working-directory cannot be set directly, this is why it's necessary to add this option.
 
 - An updated `README` that uses the latest version of the used actions and additionally, some more information regarding this new option with an updated advanced example.
 
Looking forward for feedback - although this working perfectly for me at the moment, I still can't guarantee that there is a better option to do this.
