### PR TITLE
deps: upgrade action versions for CI

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -75,7 +75,7 @@ runs:
   steps:
     - id: install_go
       if: ${{ inputs.install-go != 'false' }}
-      uses: WillAbides/setup-go-faster@v1.7.0
+      uses: WillAbides/setup-go-faster@v1.8.0
       with:
         go-version: "1.17.x"
     - uses: actions/cache@v3

--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
       uses: WillAbides/setup-go-faster@v1.7.0
       with:
         go-version: "1.17.x"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       if: ${{ inputs.merge-files == '' }}
       with:
         path: |


### PR DESCRIPTION
This PR updates the using action/cache to v3, rather than v2.
ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/