### PR TITLE
Update used go version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If Staticcheck is the only action in your job, this option can usually be left o
 If your job already installs Go prior to running Staticcheck, for example to run unit tests, it is best to set this option to `false`.
 
 The latest release of Staticcheck works with the last two minor releases of Go.
-The action itself requires at least Go 1.16.
+The action itself requires at least Go 1.19.
 
 ### `cache-key`
 

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ inputs:
       Let the action install a version of Go appropriate for building and running Staticcheck.
       If set to false, the action expects you to have installed Go already.
       The latest release of Staticcheck works with the last two minor releases of Go.
-      The action itself requires at least Go 1.16.
+      The action itself requires at least Go 1.19.
     required: true
     default: true
   cache-key:


### PR DESCRIPTION
Now, I found Go v1.17.0 is installed in action and the error is occurred.
Then, I saw original repository(staticcheck-action) and found maintainer is planning to updating this action to v1.3.0
https://github.com/dominikh/staticcheck-action/blob/master/CHANGES.md

However, the default branch README and action.yml was not updated. That's why I open the pull request.

When it's time to update, I hope you take this in.
