### PR TITLE
Update installed Go version to 1.20.x

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,7 @@ runs:
       if: ${{ inputs.install-go != 'false' }}
       uses: WillAbides/setup-go-faster@v1.8.0
       with:
-        go-version: "1.19.x"
+        go-version: "1.20.x"
     - uses: actions/cache@v3
       if: ${{ inputs.merge-files == '' }}
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,7 @@ runs:
       if: ${{ inputs.install-go != 'false' }}
       uses: WillAbides/setup-go-faster@v1.8.0
       with:
-        go-version: "1.20.x"
+        go-version: "1.21.x"
     - uses: actions/cache@v3
       if: ${{ inputs.merge-files == '' }}
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -75,7 +75,7 @@ runs:
   steps:
     - id: install_go
       if: ${{ inputs.install-go != 'false' }}
-      uses: WillAbides/setup-go-faster@v1.8.0
+      uses: WillAbides/setup-go-faster@v1.13.0
       with:
         go-version: "1.21.x"
     - uses: actions/cache@v3


### PR DESCRIPTION
DateTime is not declared by package time until go version 1.20

```
023-06-02T15:20:04.9194211Z ##[group]Run dominikh/staticcheck-action@v1.3.0
2023-06-02T15:20:04.9194492Z with:
2023-06-02T15:20:04.9194681Z   version: 2023.1.3
2023-06-02T15:20:04.9194893Z   min-go-version: module
2023-06-02T15:20:04.9195084Z   checks: inherit
2023-06-02T15:20:04.9195278Z   install-go: true
2023-06-02T15:20:04.9195743Z   working-directory: .
2023-06-02T15:20:04.9195944Z   output-format: text
2023-06-02T15:20:04.9196146Z ##[endgroup]
2023-06-02T15:20:04.9508578Z ##[group]Run WillAbides/setup-go-faster@v1.8.0
2023-06-02T15:20:04.9509021Z with:
2023-06-02T15:20:04.9509301Z   go-version: 1.19.x
2023-06-02T15:20:04.9509790Z ##[endgroup]
2023-06-02T15:20:04.9572404Z ##[group]Run src/run
2023-06-02T15:20:04.9572878Z [36;1msrc/run[0m
2023-06-02T15:20:04.9636280Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
2023-06-02T15:20:04.9636579Z env:
2023-06-02T15:20:04.9636786Z   DEBUG: 
2023-06-02T15:20:04.9637003Z   IGNORE_LOCAL_GO: 
2023-06-02T15:20:04.9637219Z   GO_VERSION: 1.19.x
2023-06-02T15:20:04.9637514Z ##[endgroup]
2023-06-02T15:20:05.8198698Z /opt/hostedtoolcache/go/1.19.9/x64 already exists
2023-06-02T15:20:06.5717591Z ##[group]Run actions/cache@v3
2023-06-02T15:20:06.5717806Z with:
2023-06-02T15:20:06.5718042Z   path: /home/runner/work/_temp/staticcheck
/home/runner/.cache/go-build

2023-06-02T15:20:06.5718416Z   key: staticcheck-Linux--85f769743ef1262edfee36ccd0119aff4df332c6
2023-06-02T15:20:06.5718722Z   restore-keys: staticcheck-Linux--

2023-06-02T15:20:06.5718952Z   enableCrossOsArchive: false
2023-06-02T15:20:06.5719178Z   fail-on-cache-miss: false
2023-06-02T15:20:06.5719393Z   lookup-only: false
2023-06-02T15:20:06.5719575Z env:
2023-06-02T15:20:06.5719795Z   GOROOT: /opt/hostedtoolcache/go/1.19.9/x64
2023-06-02T15:20:06.5720017Z ##[endgroup]
2023-06-02T15:20:07.2240308Z Cache not found for input keys: staticcheck-Linux--85f769743ef1262edfee36ccd0119aff4df332c6, staticcheck-Linux--
2023-06-02T15:20:07.2351729Z ##[group]Run export STATICCHECK_CACHE="/home/runner/work/_temp/staticcheck"
2023-06-02T15:20:07.2352087Z [36;1mexport STATICCHECK_CACHE="/home/runner/work/_temp/staticcheck"[0m
2023-06-02T15:20:07.2352396Z [36;1mgo install "honnef.co/go/tools/cmd/staticcheck@${version}"[0m
2023-06-02T15:20:07.2352681Z [36;1mecho "::add-matcher::$GITHUB_ACTION_PATH/matchers.json"[0m
2023-06-02T15:20:07.2352953Z [36;1mwrite_output() {[0m
2023-06-02T15:20:07.2353163Z [36;1m  if [ -z "${file}" ]; then[0m
2023-06-02T15:20:07.2353343Z [36;1m    cat[0m
2023-06-02T15:20:07.2353518Z [36;1m  else[0m
2023-06-02T15:20:07.2353703Z [36;1m    cat >"${file}"[0m
2023-06-02T15:20:07.2353888Z [36;1m  fi[0m
2023-06-02T15:20:07.2354043Z [36;1m}[0m
2023-06-02T15:20:07.2354231Z [36;1mif [ -z "${merge}" ]; then[0m
2023-06-02T15:20:07.2354559Z [36;1m  $(go env GOPATH)/bin/staticcheck -tags "${buildTags}" -checks "${checks}" -f "${format}" -go "${minGoVersion}" ./... | write_output[0m
2023-06-02T15:20:07.2354840Z [36;1melse[0m
2023-06-02T15:20:07.2355020Z [36;1m  IFS=$'\n'[0m
2023-06-02T15:20:07.2355486Z [36;1m  $(go env GOPATH)/bin/staticcheck -checks "${checks}" -f "${format}" -merge ${merge} | write_output[0m
2023-06-02T15:20:07.2355745Z [36;1mfi[0m
2023-06-02T15:20:07.2410761Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
2023-06-02T15:20:07.2411004Z env:
2023-06-02T15:20:07.2411397Z   GOROOT: /opt/hostedtoolcache/go/1.19.9/x64
2023-06-02T15:20:07.2411950Z   version: 2023.1.3
2023-06-02T15:20:07.2412122Z   buildTags: 
2023-06-02T15:20:07.2412314Z   minGoVersion: module
2023-06-02T15:20:07.2412510Z   checks: inherit
2023-06-02T15:20:07.2412678Z   format: text
2023-06-02T15:20:07.2412854Z   file: 
2023-06-02T15:20:07.2413021Z   merge: 
2023-06-02T15:20:07.2413182Z ##[endgroup]
2023-06-02T15:20:07.4048374Z go: downloading honnef.co/go/tools v0.4.3
2023-06-02T15:20:08.2878823Z go: downloading golang.org/x/tools v0.4.1-0.20221208213631-3f74d914ae6d
2023-06-02T15:20:08.8083634Z go: downloading golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a
2023-06-02T15:20:11.6093632Z go: downloading golang.org/x/sys v0.3.0
2023-06-02T15:20:11.6139117Z go: downloading github.com/BurntSushi/toml v1.2.1
2023-06-02T15:20:12.2194810Z go: downloading golang.org/x/mod v0.7.0
2023-06-02T15:22:17.8376951Z ##[error]go/cmd/playground/main.go:8:25: DateTime not declared by package time (compile)
2023-06-02T15:22:17.8491517Z ##[error]Process completed with exit code 1.
```