### PR TITLE
Update the version of actions/cache to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
       uses: WillAbides/setup-go-faster@v1.8.0
       with:
         go-version: "1.19.x"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: ${{ inputs.merge-files == '' }}
       with:
         path: |


### PR DESCRIPTION
I updated the version of actions/cache to v4 from v3.
This is the because show following warning message when using staticcheck-action.
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

The [actions/cache@v4](https://github.com/actions/cache) is not include breaking changes.
