### PR TITLE
Making cache optional

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,11 @@ inputs:
       The action itself requires at least Go 1.16.
     required: true
     default: true
+  cache:
+    description: |
+      Used to specify whether caching is needed. Defaults to true.
+    required: false
+    default: true
   cache-key:
     description: |
       String to include in the cache key, in addition to the default, which is runner.os.
@@ -79,7 +84,7 @@ runs:
       with:
         go-version: "stable"
     - uses: actions/cache@v4
-      if: ${{ inputs.merge-files == '' }}
+      if: ${{ inputs.merge-files == '' && inputs.cache != 'false' }}
       with:
         path: |
           ${{ runner.temp }}/staticcheck


### PR DESCRIPTION
Related to https://github.com/dominikh/staticcheck-action/issues/19

Default behaviour without setting the flag:
![image](https://github.com/user-attachments/assets/703ee14e-7351-429f-b712-df48a4484105)

After setting the flag to false:
![image](https://github.com/user-attachments/assets/966a6ce6-ca55-4260-bef6-4cfbac574cf6)

After setting up a read-only cache on the consumer of this action:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/60960894-9aae-43c7-bce9-f290850d72ad" />
