### PR TITLE
Adds CI workflow to test the action on go-tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Testing the action for dependencies
+
+on:
+  push: 
+  pull_request:
+
+permissions: 
+  contents: read
+
+jobs:
+  ci:
+    name: go-tools
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
+        go: ["1.25", "1.26"]
+        godebug: ["gotypesalias=0", "gotypesalias=1"]
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with: { fetch-depth: 1, persist-credentials: false }
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with: { fetch-depth: 1, persist-credentials: false, path: sub, repository: dominikh/go-tools, ref: ff63afafc529279f454e02f1d060210bd4263951 } # v0.7.0
+    - uses: actions/setup-go@v6
+      with: { go-version: "${{ matrix.go }}" }
+    - uses: ./
+      with:
+        version: "latest"
+        min-go-version: "module"
+        install-go: false
+        cache-key: ${{ matrix.go }}
+        working-directory: sub


### PR DESCRIPTION
- resolves #25 

This PR adds a workflow with a job similar to the one in original CI workflow file of go-tools repository.